### PR TITLE
Fix errors stopping plugin from running on 5.4

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -228,7 +228,9 @@ function get_member_articles( $member = null ) {
 
         if( !empty( $article ) ) {
 
-        	if ( !empty( $post = get_post( $article ) ) ) {
+	        $post = get_post( $article );
+
+        	if ( !empty( $post ) ) {
 		        $articles[] = $post;
 	        }
 

--- a/includes/widgets.php
+++ b/includes/widgets.php
@@ -9,8 +9,8 @@ namespace ots;
  */
 function register_widgets() {
 
-    register_widget( TeamSidebarWidget::class );
-    register_widget( TeamMainWidget::class );
+    register_widget( '\ots\TeamSidebarWidget' );
+    register_widget( '\ots\TeamMainWidget' );
 
 }
 


### PR DESCRIPTION
Includes fix for the unsupported `empty()` call and an issue with using the syntax `SomeClass::class` to get the fully qualified class name that is unsupported on php 5.4